### PR TITLE
fix: project slug to lower case

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -2,7 +2,7 @@ export const api = `https://dhbern.github.io/parzival-static-api/api`;
 
 export const teipb = `http://localhost:8081/exist/apps/parzival/api`;
 
-export const iiif = `https://iiif.ub.unibe.ch/image/v3/Parzival`;
+export const iiif = `https://iiif.ub.unibe.ch/image/v3/parzival`;
 
 export const summaryLabel = 'Fassungen';
 


### PR DESCRIPTION
The requests for info.jsons fail due to the project slug which is starting with a capital letter "Parzival".

https://iiif.ub.unibe.ch/image/v3/Parzival/mk074v.jpf/info.json -> fails
https://iiif.ub.unibe.ch/image/v3/parzival/mk074v.jpf/info.json -> works