### PR TITLE
fix indefinite scrolling, when target verse is on bottom.

### DIFF
--- a/src/routes/textzeugen/[[sigla]]/[[thirties]]/[[verse]]/TextzeugenContent.svelte
+++ b/src/routes/textzeugen/[[sigla]]/[[thirties]]/[[verse]]/TextzeugenContent.svelte
@@ -26,7 +26,10 @@
 			(entries) => {
 				entries.forEach((entry) => {
 					if (entry.isIntersecting) {
-						if (programmaticScroll) {
+						const isOnBottom =
+							scrollContainer.scrollHeight - scrollContainer.clientHeight ===
+							scrollContainer.scrollTop;
+						if (programmaticScroll || isOnBottom) {
 							return;
 						}
 						if (entry.target instanceof HTMLElement) {
@@ -182,7 +185,7 @@
 				scrollContainer.scrollTop
 			) {
 				const dataset = verse.closest('.page').dataset;
-				if (dataset) {
+				if (dataset?.next) {
 					await localPageChange(dataset);
 				}
 			}


### PR DESCRIPTION
https://github.com/DHBern/presentation_parzival/issues/162

I _think_ i fixed the bug. My assumption: This only happens with verses on the last page of their respective Witnes (Textzeuge)?

If it happens on verses that are not on their last page my fix won't work. :-)

Thank you for testing.