### PR TITLE
style: change size of popover content

### DIFF
--- a/src/routes/textzeugen/[[sigla=handles]]/[[thirties=thirties]]/[[verse]]/+page.svelte
+++ b/src/routes/textzeugen/[[sigla=handles]]/[[thirties=thirties]]/[[verse]]/+page.svelte
@@ -181,12 +181,14 @@
 									{sigilFromHandle(info.sigla)}
 								{/snippet}
 								{#snippet content()}
-									{@html metadataFromHandle(info.sigla)['info-h2']}
-									(<a
-										class="anchor text-primary-100"
-										href="{base}/hsverz#{sigilFromHandle(info.sigla)}"
+									<div class="h6">
+										{@html metadataFromHandle(info.sigla)['info-h2']}
+										<a
+											class="anchor text-primary-100"
+											href="{base}/hsverz#{sigilFromHandle(info.sigla)}"
 										>zum Verzeichnis
-									</a>)
+										</a>
+									</div>
 								{/snippet}
 							</Popover>
 						</h2>


### PR DESCRIPTION
Kept the changes minimal and decoupled by wrapping into a div in the parents template. Overrides the baked in h2 from the data in this case.