### PR TITLE
fix scroll function to only scroll one container

### DIFF
--- a/src/routes/fassungen/[thirties=thirties]/FassungenSyncContent.svelte
+++ b/src/routes/fassungen/[thirties=thirties]/FassungenSyncContent.svelte
@@ -22,11 +22,13 @@
 				const targetVerse = node.parentElement?.querySelector(
 					`[data-verse="${page.data.thirties}.01"]`
 				);
-				if (targetVerse) {
-					targetVerse?.scrollIntoView({
-						behavior: 'instant',
-						block: 'start',
-						inline: 'nearest'
+				if (scrollContainer && targetVerse) {
+					scrollContainer?.scrollTo({
+						top:
+							scrollContainer?.scrollTop +
+							Number(targetVerse.parentElement?.getBoundingClientRect().top) -
+							scrollContainer?.getBoundingClientRect().top,
+						behavior: 'instant'
 					});
 					correctPos = true;
 				}


### PR DESCRIPTION
I just adjusted the scrolling function to be the same as in FassungenContent.svelte.

https://github.com/DHBern/presentation_parzival/issues/195
