### PR TITLE
update URL_STATIC_API to https://data.parzival.digitaleditions.ch/api

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"docker:start": "docker pull existdb/existdb:6.2.0 && docker run -d -p 8081:8080 -p 8444:8443 --name teipublisher existdb/existdb:6.2.0",
-		"installXar": "wget https://dhbern.github.io/parzival-static-api/parzival-0.2.xar -O parzival-0.2.xar && xst package install parzival-0.2.xar && rm parzival-0.2.xar",
+		"installXar": "wget https://data.parzival.digitaleditions.ch/parzival-0.2.xar -O parzival-0.2.xar && xst package install parzival-0.2.xar && rm parzival-0.2.xar",
 		"docker:stop": "docker stop teipublisher && docker rm teipublisher",
 		"dev": "vite dev",
 		"build": "svelte-kit sync && vite build",

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,4 +1,4 @@
-export const URL_STATIC_API = `https://dhbern.github.io/parzival-static-api/api`;
+export const URL_STATIC_API = `https://data.parzival.digitaleditions.ch/api`;
 
 export const URL_TEI_PB = `http://localhost:8081/exist/apps/parzival/api`;
 

--- a/src/routes/fassungen/[thirties=thirties]/+page.svelte
+++ b/src/routes/fassungen/[thirties=thirties]/+page.svelte
@@ -474,7 +474,7 @@
 				Eintextedition als <a
 					class="anchor"
 					target="_blank"
-					href="https://dhbern.github.io/parzival-static-api/api/pdf/eintextedition.pdf#page={data.thirties}"
+					href="https://data.parzival.digitaleditions.ch/api/pdf/eintextedition.pdf#page={data.thirties}"
 				>
 					PDF
 				</a> aufrufen

--- a/src/routes/monotext/+page.svelte
+++ b/src/routes/monotext/+page.svelte
@@ -9,7 +9,7 @@
 		<ErlaeuterungenEintextEdition />
 	</ExpandableContent>
 	<embed
-		src="https://dhbern.github.io/parzival-static-api/api/pdf/eintextedition.pdf"
+		src="https://data.parzival.digitaleditions.ch/api/pdf/eintextedition.pdf"
 		width="100%"
 		height="800px"
 		type="application/pdf"


### PR DESCRIPTION
The static API is now live at https://data.parzival.digitaleditions.ch/api.

This requires changes in four locations. Some instances could likely be replaced by ${URL_STATIC_API} to rely on the const more encompassingly.

I suggest either making sure the wget command in `packages.json` follows the redirect or merging this before the next build.