### PR TITLE
style: mark links individually

### DIFF
--- a/src/routes/fassungen/[thirties=thirties]/FassungenContent.svelte
+++ b/src/routes/fassungen/[thirties=thirties]/FassungenContent.svelte
@@ -60,7 +60,7 @@
 			{/if}
 		{/if}
 	</h2>
-	<div class="inline [&_ul,&_li]:inline [&_li]:mr-1">
+	<div class="inline [&_ul,&_li]:inline [&_li]:mr-1 [&_a]:anchor">
 		{@html currentDistribution}
 	</div>
 </div>

--- a/src/routes/fassungen/[thirties=thirties]/FassungenSyncContent.svelte
+++ b/src/routes/fassungen/[thirties=thirties]/FassungenSyncContent.svelte
@@ -62,7 +62,7 @@
 					{/if}
 				{/if}
 			</h2>
-			<div class="inline [&_ul,&_li]:inline [&_li]:mr-1 anchor">
+			<div class="inline [&_ul,&_li]:inline [&_li]:mr-1 [&_a]:anchor">
 				{@html distributions[i][page.data.thirties]}
 			</div>
 		</div>


### PR DESCRIPTION
Solves the issue that on hover over a link in the "Siglenleiste" all are undelined suggesting that there is one link only. However there are n links and they should visually behave as individual links.

Before: Fr58 is hovered, but all witnesses are underlined:

<img width="877" height="572" alt="a_before" src="https://github.com/user-attachments/assets/4e5d4f6e-53ad-40fc-907f-60da851bc648" />

with this PR: Fr58 is hovered and only that witnesses link is underlined.
<img width="877" height="492" alt="b_after" src="https://github.com/user-attachments/assets/db1feca3-8035-4263-bd16-e709e6d09506" />
