### PR TITLE
Slight restyle of Transcription page and vers selection

### DIFF
--- a/src/lib/components/TextzeugenSelector.svelte
+++ b/src/lib/components/TextzeugenSelector.svelte
@@ -12,28 +12,24 @@
 	let selection = $state(selectedSigla);
 </script>
 
-<div>
-	<div class="flex gap-6 my-3">
-		{#each Array.from({ length: 2 }) as _, i}
-			<label>
-				{#if i === 0}Textzeuge{:else}Textzeugenvergleich{/if}:
-				<select class="select my-2" bind:value={selection[i]}>
-					{#if i !== 0}
-						<option value=""> --- </option>
-					{/if}
-					{#await sigla then resolvedSigla}
-						{#each resolvedSigla as { sigil, handle }}
-							<option value={handle}>{@html sigil}</option>
-						{/each}
-					{/await}
-				</select>
-			</label>
-		{/each}
-	</div>
-	<div class="flex max-w-full items-baseline gap-1 my-3">
-		<VerseSelector
-			targetPath={`/transkriptionen/${selection.filter((e) => !!e).join('-')}`}
-			{coordinates}
-		/>
-	</div>
+<div class="flex flex-wrap items-baseline gap-x-10">
+	{#each Array.from({ length: 2 }) as _, i}
+		<label class="flex items-baseline gap-2 shrink-0 font-bold">
+			{#if i === 0}Textzeuge{:else}Textzeugenvergleich{/if}:
+			<select class="select font-normal" bind:value={selection[i]}>
+				{#if i !== 0}
+					<option value=""> --- </option>
+				{/if}
+				{#await sigla then resolvedSigla}
+					{#each resolvedSigla as { sigil, handle }}
+						<option value={handle}>{@html sigil}</option>
+					{/each}
+				{/await}
+			</select>
+		</label>
+	{/each}
+	<VerseSelector
+		targetPath={`/transkriptionen/${selection.filter((/** @type {string} */ e) => !!e).join('-')}`}
+		{coordinates}
+	/>
 </div>

--- a/src/lib/components/VerseSelector.svelte
+++ b/src/lib/components/VerseSelector.svelte
@@ -85,6 +85,7 @@
 			<input
 				type="number"
 				placeholder="Dreißiger"
+				aria-label="Dreißiger"
 				class="input inline max-w-28"
 				min="1"
 				max={NUMBER_OF_PAGES}
@@ -94,14 +95,21 @@
 			/>.<input
 				type="number"
 				placeholder="Vers"
+				aria-label="Vers"
 				class="input max-w-20"
 				min="1"
 				max={thirtiesVal === 257 ? 32 : 30}
 				oninput={handleInput}
 				bind:this={verse}
 				value={verseVal}
-			/>-<input type="text" placeholder="Zusatz" class="input max-w-20" bind:this={additional} />
-			<button aria-label="suchen" class="btn preset-filled btn-sm shrink-0 grow-0">Anzeigen</button>
+			/>-<input
+				type="text"
+				placeholder="Zusatz"
+				aria-label="Zusatz"
+				class="input max-w-20"
+				bind:this={additional}
+			/>
+			<button class="btn preset-filled btn-sm shrink-0 grow-0">Anzeigen</button>
 		</span>
 	{/if}
 </form>

--- a/src/lib/components/VerseSelector.svelte
+++ b/src/lib/components/VerseSelector.svelte
@@ -71,7 +71,7 @@
 </script>
 
 <form
-	class="flex max-w-full items-baseline gap-1 my-3"
+	class="flex flex-wrap max-w-full items-baseline gap-1"
 	onsubmit={(e) => {
 		e.preventDefault();
 		if (thirties && verse && validateMinMax(thirties) && validateMinMax(verse)) {
@@ -79,27 +79,29 @@
 		}
 	}}
 >
-	<p>Vers:</p>
+	<p class="font-bold">Vers:</p>
 	{#if typeof coordinates === 'object'}
-		<input
-			type="number"
-			placeholder="Dreißiger"
-			class="input inline max-w-28"
-			min="1"
-			max={NUMBER_OF_PAGES}
-			oninput={handleInput}
-			bind:this={thirties}
-			bind:value={thirtiesVal}
-		/>.<input
-			type="number"
-			placeholder="Vers"
-			class="input max-w-20"
-			min="1"
-			max={thirtiesVal === 257 ? 32 : 30}
-			oninput={handleInput}
-			bind:this={verse}
-			value={verseVal}
-		/>-<input type="text" placeholder="Zusatz" class="input max-w-20" bind:this={additional} />
-		<button aria-label="suchen" class="btn preset-filled btn-sm shrink-0 grow-0">Anzeigen</button>
+		<span class="inline-flex items-baseline gap-1">
+			<input
+				type="number"
+				placeholder="Dreißiger"
+				class="input inline max-w-28"
+				min="1"
+				max={NUMBER_OF_PAGES}
+				oninput={handleInput}
+				bind:this={thirties}
+				bind:value={thirtiesVal}
+			/>.<input
+				type="number"
+				placeholder="Vers"
+				class="input max-w-20"
+				min="1"
+				max={thirtiesVal === 257 ? 32 : 30}
+				oninput={handleInput}
+				bind:this={verse}
+				value={verseVal}
+			/>-<input type="text" placeholder="Zusatz" class="input max-w-20" bind:this={additional} />
+			<button aria-label="suchen" class="btn preset-filled btn-sm shrink-0 grow-0">Anzeigen</button>
+		</span>
 	{/if}
 </form>

--- a/src/routes/fassungen/[thirties=thirties]/+page.svelte
+++ b/src/routes/fassungen/[thirties=thirties]/+page.svelte
@@ -510,7 +510,7 @@
 					max={NUMBER_OF_PAGES}
 					bind:value={gotoThirties}
 				/>
-				<button class="btn preset-filled-primary-500">Anzeigen</button>
+				<button class="btn preset-filled">Anzeigen</button>
 			</form>
 
 			<p>

--- a/src/routes/fassungen/[thirties=thirties]/+page.svelte
+++ b/src/routes/fassungen/[thirties=thirties]/+page.svelte
@@ -527,9 +527,7 @@
 
 		<div class="flex flex-wrap items-center gap-x-6 gap-y-3 ml-auto">
 			<fieldset class="flex items-center gap-3 [&>legend]:float-left">
-				<legend class="text-lg font-bold font-serif">
-					Fassungen:
-				</legend>
+				<legend class="text-lg font-bold font-serif"> Fassungen: </legend>
 				{#each columnKeys as key, i}
 					{@const isLastVisible = fassungenVisible[i] && visibleCount === 1}
 					<label class="flex items-center gap-1">

--- a/src/routes/transkriptionen/[[sigla=handles]]/[[thirties=thirties]]/[[verse]]/+page.svelte
+++ b/src/routes/transkriptionen/[[sigla=handles]]/[[thirties=thirties]]/[[verse]]/+page.svelte
@@ -42,7 +42,7 @@
 			return;
 		}
 		const direction = e.key === 'ArrowLeft' ? -1 : 1;
-        const successfullNav = pageSelectors[0]?.step(direction)
+		const successfullNav = pageSelectors[0]?.step(direction);
 		if (successfullNav) {
 			e.preventDefault();
 		}
@@ -201,38 +201,36 @@
 		<h1 class="h1 min-w-0">Transkriptionen</h1>
 		<Zitierempfehlung mode="popup" />
 	</div>
-	<div class="grid gap-6 md:grid-cols-2 md:my-8">
-		<div class="flex flex-col gap-6">
-			<div>
-				<a
-					target="_blank"
-					rel="noopener noreferrer"
-					href="/erlaeuterungen#transkriptionen-auch-relevant-fuer-die-darstellung-in-der-verssynopse"
-					class="anchor"
-					aria-label="Erläuterungen (öffnet in neuem Tab)">Erläuterungen</a
-				>
-				zu den Transkriptionen
-			</div>
-			{#if data.content?.length > 1}
-				<div>
-					<Switch
-						thumbInactive="bg-surface-800"
-						controlInactive="bg-surface-100"
-						name="synchro"
-						checked={synchro}
-						onCheckedChange={(e) => (synchro = e.checked)}
-					>
-						synchron scrollen
-					</Switch>
-				</div>
-			{/if}
+	<div class="flex flex-col">
+		<div>
+			<a
+				target="_blank"
+				rel="noopener noreferrer"
+				href="/erlaeuterungen#transkriptionen-auch-relevant-fuer-die-darstellung-in-der-verssynopse"
+				class="anchor"
+				aria-label="Erläuterungen (öffnet in neuem Tab)">Erläuterungen</a
+			>
+			zu den Transkriptionen
 		</div>
-		<TextzeugenSelector
-			sigla={[...data.codices, ...data.fragments]}
-			{selectedSigla}
-			coordinates={[data.thirties, data.verse]}
-		/>
+		{#if data.content?.length > 1}
+			<div>
+				<Switch
+					thumbInactive="bg-surface-800"
+					controlInactive="bg-surface-100"
+					name="synchro"
+					checked={synchro}
+					onCheckedChange={(e) => (synchro = e.checked)}
+				>
+					synchron scrollen
+				</Switch>
+			</div>
+		{/if}
 	</div>
+	<TextzeugenSelector
+		sigla={[...data.codices, ...data.fragments]}
+		{selectedSigla}
+		coordinates={[data.thirties, data.verse]}
+	/>
 </section>
 {#if data.content}
 	<div class="grid grid-cols-[repeat(auto-fit,minmax(550px,1fr))] gap-4">

--- a/src/routes/transkriptionen/[[sigla=handles]]/[[thirties=thirties]]/[[verse]]/+page.svelte
+++ b/src/routes/transkriptionen/[[sigla=handles]]/[[thirties=thirties]]/[[verse]]/+page.svelte
@@ -42,8 +42,8 @@
 			return;
 		}
 		const direction = e.key === 'ArrowLeft' ? -1 : 1;
-		const successfullNav = pageSelectors[0]?.step(direction);
-		if (successfullNav) {
+		const successfulNav = pageSelectors[0]?.step(direction);
+		if (successfulNav) {
 			e.preventDefault();
 		}
 	}


### PR DESCRIPTION
In order to have a denser layout showing more of the actual content of importance (the actual transcriptions) controls and forms are rearranged. Vertical gaps are removed or reduced. Controls for verse selection and witness selections are flexing on one line (wrapping on smaller displays). 

Style only PR, no changes to business logic, routing asf. 