### PR TITLE
refactor: enlarge dreissiger input by 1em

### DIFF
--- a/src/routes/fassungen/[thirties=thirties]/+page.svelte
+++ b/src/routes/fassungen/[thirties=thirties]/+page.svelte
@@ -505,7 +505,7 @@
 					id="goto-thirties"
 					type="number"
 					placeholder="Dreißiger"
-					class="input inline w-[4em] mr-1"
+					class="input inline w-[5em] mr-1"
 					min="1"
 					max={NUMBER_OF_PAGES}
 					bind:value={gotoThirties}


### PR DESCRIPTION
The space was tight for three digit dreissiger numbers when the htmls native spin buttons appear in the input of type number 